### PR TITLE
feat: OAuth support

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -11,13 +11,12 @@ DB_PASSWORD=password
 PUBLIC_URL=http://localhost:18055
 LOG_LEVEL=trace
 CORS_ENABLED=true
-CORS_ORIGIN=http://localhost:13010
+CORS_ORIGIN=http://localhost:13000,http://localhost:13010
 SESSION_COOKIE_NAME=dash_session_token
-SESSION_COOKIE_SECURE=true
 SESSION_COOKIE_SAME_SITE=strict
 # https://docs.directus.io/self-hosted/config-options.html#security
 KEY=directus
-SECRET=
+SECRET=xxx
 # https://docs.directus.io/self-hosted/config-options.html#sso-oauth2-and-openid
 AUTH_GITHUB_CLIENT_ID=
 AUTH_GITHUB_CLIENT_SECRET=

--- a/.env.production.example
+++ b/.env.production.example
@@ -11,11 +11,11 @@ DB_PASSWORD=
 PUBLIC_URL=
 LOG_LEVEL=info
 CORS_ENABLED=true
+CORS_ORIGIN=https://globalping.io,https://dash.globalping.io,https://staging.globalping.io,http://localhost:13000
 SESSION_COOKIE_NAME=dash_session_token
 SESSION_COOKIE_DOMAIN=globalping.io
 SESSION_COOKIE_SECURE=true
 SESSION_COOKIE_SAME_SITE=strict
-CORS_ORIGIN=https://dash.globalping.io
 # https://docs.directus.io/self-hosted/config-options.html#security
 KEY=directus
 SECRET=
@@ -38,7 +38,7 @@ AUTH_GITHUB_SCOPE=read:user,user:email
 AUTH_GITHUB_FIRST_NAME_KEY=name
 AUTH_GITHUB_LAST_NAME_KEY=login
 AUTH_GITHUB_IDENTIFIER_KEY=id
-AUTH_GITHUB_REDIRECT_ALLOW_LIST=https://dash.globalping.io
+AUTH_GITHUB_REDIRECT_ALLOW_LIST=https://globalping.io,https://dash.globalping.io,https://auth.globalping.io,https://staging.globalping.io,http://localhost:13000
 
 # GitHub API
 # A classic token (not scoped), required permissions are: read:org, read:user

--- a/scripts/docker-ls.js
+++ b/scripts/docker-ls.js
@@ -1,5 +1,5 @@
 import { readdirSync, statSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { join } from 'path/posix';
 
 const findDirectoriesWithPackageJson = (dir) => {
 	const result = [];

--- a/snapshots/collections-schema.yml
+++ b/snapshots/collections-schema.yml
@@ -19,7 +19,7 @@ collections:
       note: null
       preview_url: null
       singleton: false
-      sort: 2
+      sort: 3
       sort_field: null
       translations:
         - language: en-US
@@ -28,6 +28,30 @@ collections:
       versioning: false
     schema:
       name: gp_adopted_probes
+  - collection: gp_apps
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: gp_apps
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 1
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: gp_apps
   - collection: gp_credits
     meta:
       accountability: all
@@ -45,7 +69,7 @@ collections:
       note: null
       preview_url: null
       singleton: false
-      sort: 4
+      sort: 5
       sort_field: null
       translations:
         - language: en-US
@@ -71,7 +95,7 @@ collections:
       note: null
       preview_url: null
       singleton: false
-      sort: 5
+      sort: 6
       sort_field: null
       translations:
         - language: en-US
@@ -97,7 +121,7 @@ collections:
       note: null
       preview_url: null
       singleton: false
-      sort: 6
+      sort: 7
       sort_field: null
       translations:
         - language: en-US
@@ -123,7 +147,7 @@ collections:
       note: null
       preview_url: null
       singleton: false
-      sort: 3
+      sort: 4
       sort_field: null
       translations:
         - language: en-US
@@ -149,7 +173,7 @@ collections:
       note: null
       preview_url: null
       singleton: false
-      sort: 1
+      sort: 2
       sort_field: null
       translations:
         - language: en-US
@@ -175,7 +199,7 @@ collections:
       note: null
       preview_url: null
       singleton: false
-      sort: 7
+      sort: 8
       sort_field: null
       translations: null
       unarchive_value: null
@@ -1326,6 +1350,434 @@ fields:
       has_auto_increment: false
       foreign_key_table: null
       foreign_key_column: null
+  - collection: gp_apps
+    field: id
+    type: uuid
+    meta:
+      collection: gp_apps
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: gp_apps
+      data_type: char
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: gp_apps
+    field: user_created
+    type: string
+    meta:
+      collection: gp_apps
+      conditions: null
+      display: user
+      display_options: null
+      field: user_created
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar.$thumbnail}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      sort: 8
+      special:
+        - user-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_created
+      table: gp_apps
+      data_type: char
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: gp_apps
+    field: date_created
+    type: timestamp
+    meta:
+      collection: gp_apps
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 9
+      special:
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: gp_apps
+      data_type: timestamp
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: gp_apps
+    field: user_updated
+    type: string
+    meta:
+      collection: gp_apps
+      conditions: null
+      display: user
+      display_options: null
+      field: user_updated
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        template: '{{avatar.$thumbnail}} {{first_name}} {{last_name}}'
+      readonly: true
+      required: false
+      sort: 10
+      special:
+        - user-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: user_updated
+      table: gp_apps
+      data_type: char
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: directus_users
+      foreign_key_column: id
+  - collection: gp_apps
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: gp_apps
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 11
+      special:
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: gp_apps
+      data_type: timestamp
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: gp_apps
+    field: name
+    type: string
+    meta:
+      collection: gp_apps
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 2
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: gp_apps
+      data_type: varchar
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: gp_apps
+    field: secret
+    type: string
+    meta:
+      collection: gp_apps
+      conditions: null
+      display: null
+      display_options: null
+      field: secret
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 3
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: secret
+      table: gp_apps
+      data_type: varchar
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: gp_apps
+    field: redirect_url
+    type: string
+    meta:
+      collection: gp_apps
+      conditions: null
+      display: null
+      display_options: null
+      field: redirect_url
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: redirect_url
+      table: gp_apps
+      data_type: varchar
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: gp_apps
+    field: grants
+    type: json
+    meta:
+      collection: gp_apps
+      conditions: null
+      display: null
+      display_options: null
+      field: grants
+      group: null
+      hidden: false
+      interface: tags
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 5
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: grants
+      table: gp_apps
+      data_type: longtext
+      default_value: []
+      max_length: 4294967295
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: gp_apps
+    field: access_token_lifetime
+    type: integer
+    meta:
+      collection: gp_apps
+      conditions: null
+      display: null
+      display_options: null
+      field: access_token_lifetime
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: access_token_lifetime
+      table: gp_apps
+      data_type: int
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: gp_apps
+    field: refresh_token_lifetime
+    type: integer
+    meta:
+      collection: gp_apps
+      conditions: null
+      display: null
+      display_options: null
+      field: refresh_token_lifetime
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: refresh_token_lifetime
+      table: gp_apps
+      data_type: int
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
   - collection: gp_credits
     field: id
     type: integer
@@ -2397,7 +2849,7 @@ fields:
       options: null
       readonly: false
       required: false
-      sort: 10
+      sort: 11
       special: null
       translations: null
       validation: null
@@ -2476,7 +2928,7 @@ fields:
       options: null
       readonly: false
       required: false
-      sort: 9
+      sort: 10
       special: null
       translations: null
       validation: null
@@ -2552,7 +3004,7 @@ fields:
       options: null
       readonly: false
       required: true
-      sort: 6
+      sort: 7
       special: null
       translations: null
       validation: null
@@ -2593,7 +3045,7 @@ fields:
       options: {}
       readonly: false
       required: false
-      sort: 8
+      sort: 9
       special:
         - cast-json
       translations: null
@@ -2712,7 +3164,7 @@ fields:
       options: null
       readonly: false
       required: true
-      sort: 7
+      sort: 8
       special: null
       translations: null
       validation: null
@@ -2726,6 +3178,89 @@ fields:
       max_length: 255
       numeric_precision: null
       numeric_scale: null
+      is_nullable: true
+      is_unique: true
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: gp_tokens
+    field: app_id
+    type: string
+    meta:
+      collection: gp_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: app_id
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        enableCreate: false
+      readonly: false
+      required: false
+      sort: 13
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: app_id
+      table: gp_tokens
+      data_type: varchar
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: gp_apps
+      foreign_key_column: id
+  - collection: gp_tokens
+    field: scopes
+    type: json
+    meta:
+      collection: gp_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: scopes
+      group: null
+      hidden: false
+      interface: tags
+      note: >-
+        A list of origins which are allowed to use the token. If empty - any
+        origin is valid. Examples of origins: "www.jsdelivr.com",
+        "www.jsdelivr.com:10000".
+      options: {}
+      readonly: false
+      required: false
+      sort: 12
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: scopes
+      table: gp_tokens
+      data_type: longtext
+      default_value:
+        - measurements
+      max_length: 4294967295
+      numeric_precision: null
+      numeric_scale: null
       is_nullable: false
       is_unique: false
       is_primary_key: false
@@ -2734,6 +3269,83 @@ fields:
       has_auto_increment: false
       foreign_key_table: null
       foreign_key_column: null
+  - collection: gp_tokens
+    field: type
+    type: string
+    meta:
+      collection: gp_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: type
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: type
+      table: gp_tokens
+      data_type: varchar
+      default_value: access_token
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: gp_tokens
+    field: parent
+    type: integer
+    meta:
+      collection: gp_tokens
+      conditions: null
+      display: null
+      display_options: null
+      field: parent
+      group: null
+      hidden: true
+      interface: select-dropdown-m2o
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 14
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: parent
+      table: gp_tokens
+      data_type: int unsigned
+      default_value: null
+      max_length: null
+      numeric_precision: 10
+      numeric_scale: 0
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: gp_tokens
+      foreign_key_column: id
   - collection: sponsors
     field: date_created
     type: timestamp
@@ -3108,6 +3720,48 @@ relations:
       constraint_name: gp_adopted_probes_userid_foreign
       on_update: RESTRICT
       on_delete: CASCADE
+  - collection: gp_apps
+    field: user_created
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: gp_apps
+      many_field: user_created
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: gp_apps
+      column: user_created
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: gp_apps_user_created_foreign
+      on_update: RESTRICT
+      on_delete: RESTRICT
+  - collection: gp_apps
+    field: user_updated
+    related_collection: directus_users
+    meta:
+      junction_field: null
+      many_collection: gp_apps
+      many_field: user_updated
+      one_allowed_collections: null
+      one_collection: directus_users
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: gp_apps
+      column: user_updated
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      constraint_name: gp_apps_user_updated_foreign
+      on_update: RESTRICT
+      on_delete: RESTRICT
   - collection: gp_credits
     field: user_id
     related_collection: directus_users
@@ -3274,6 +3928,48 @@ relations:
       foreign_key_table: directus_users
       foreign_key_column: id
       constraint_name: gp_tokens_user_updated_foreign
+      on_update: RESTRICT
+      on_delete: CASCADE
+  - collection: gp_tokens
+    field: app_id
+    related_collection: gp_apps
+    meta:
+      junction_field: null
+      many_collection: gp_tokens
+      many_field: app_id
+      one_allowed_collections: null
+      one_collection: gp_apps
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: gp_tokens
+      column: app_id
+      foreign_key_table: gp_apps
+      foreign_key_column: id
+      constraint_name: gp_tokens_app_id_foreign
+      on_update: RESTRICT
+      on_delete: CASCADE
+  - collection: gp_tokens
+    field: parent
+    related_collection: gp_tokens
+    meta:
+      junction_field: null
+      many_collection: gp_tokens
+      many_field: parent
+      one_allowed_collections: null
+      one_collection: gp_tokens
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: gp_tokens
+      column: parent
+      foreign_key_table: gp_tokens
+      foreign_key_column: id
+      constraint_name: gp_tokens_parent_foreign
       on_update: RESTRICT
       on_delete: CASCADE
   - collection: sponsors

--- a/src/extensions/migration-utils.js
+++ b/src/extensions/migration-utils.js
@@ -24,10 +24,14 @@ export async function getUserPermissions (collectionName) {
 
 		return response.json();
 	});
+
 	const permissions = response.data;
 	const readPermissions = permissions.find(({ action }) => action === 'read');
+	const createPermissions = permissions.find(({ action }) => action === 'create');
+	const updatePermissions = permissions.find(({ action }) => action === 'update');
+	const deletePermissions = permissions.find(({ action }) => action === 'delete');
 
-	return { readPermissions };
+	return { readPermissions, createPermissions, updatePermissions, deletePermissions };
 }
 
 export async function updatePermissions (readPermissions, fieldsToAdd, fieldsToRemove) {

--- a/src/extensions/migrations/20240830GP-update-token-permissions-and-indices.js
+++ b/src/extensions/migrations/20240830GP-update-token-permissions-and-indices.js
@@ -1,0 +1,58 @@
+import { getUserPermissions, updatePermissions } from '../migration-utils.js';
+
+const COLLECTION_NAME = 'gp_tokens';
+
+export async function up (knex) {
+	const permissions = await getUserPermissions(COLLECTION_NAME);
+
+	await updatePermissions({
+		...permissions.createPermissions,
+		permissions: {
+			_and: [
+				{ user_created: { _eq: '$CURRENT_USER' } },
+				{ app_id: { _null: true } },
+			],
+		},
+	}, [], []);
+
+	await updatePermissions({
+		...permissions.readPermissions,
+		permissions: {
+			_and: [
+				{ user_created: { _eq: '$CURRENT_USER' } },
+				{ app_id: { _null: true } },
+			],
+		},
+	}, [], []);
+
+	await updatePermissions({
+		...permissions.updatePermissions,
+		permissions: {
+			_and: [
+				{ user_created: { _eq: '$CURRENT_USER' } },
+				{ app_id: { _null: true } },
+			],
+		},
+	}, [], []);
+
+	await updatePermissions({
+		...permissions.deletePermissions,
+		permissions: {
+			_and: [
+				{ user_created: { _eq: '$CURRENT_USER' } },
+				{ app_id: { _null: true } },
+			],
+		},
+	}, [], []);
+
+	console.log(`User token permissions patched.`);
+
+	await knex.raw(`ALTER TABLE gp_tokens DROP INDEX value_index;`);
+	await knex.raw(`ALTER TABLE gp_tokens ADD INDEX parent_index (parent);`);
+
+	console.log(`Indices updated.`);
+}
+
+export async function down () {
+	console.log('There is no down operation for that migration.');
+}


### PR DESCRIPTION
New token fields:
 - type (access_token, refresh_token),
 - scopes (only one exists, but extensible if needed later),
 - app_id (null for personal tokens, defined for oauth tokens),
 - parent (access -> refresh) relation.

Regular users won't see anything other than personal due to permissions, but we should probably add a filter in dash FE to hide non-personal tokens from admins as well.

New collection apps:
List of OAuth apps. For now, managed manually by us. Later we may consider allowing the users to register apps themselves.