### PR TITLE
feat: migrate to directus v11

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -5,7 +5,8 @@ DB_PORT=13306
 DB_DATABASE=dashboard-globalping
 DB_USER=directus
 DB_PASSWORD=password
-DB_CHARSET=utf8mb4
+# Collation mapping from here: https://github.com/sidorares/node-mysql2/blob/bded4980065319e58a4f87d828cc355fb79f5bd3/lib/constants/charsets.js#L174
+DB_CHARSET_NUMBER=192
 
 # Directus
 # https://docs.directus.io/self-hosted/config-options.html#general

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ DB_PORT=13306
 DB_DATABASE=dashboard-globalping
 DB_USER=directus
 DB_PASSWORD=password
-DB_CHARSET=utf8mb4
+# Collation mapping from here: https://github.com/sidorares/node-mysql2/blob/bded4980065319e58a4f87d828cc355fb79f5bd3/lib/constants/charsets.js#L174
+DB_CHARSET_NUMBER=192
 
 MIGRATIONS_PATH=extensions/migrations
 # ID that will be used for the flow. Any valid UUID.

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN pnpm install
 COPY src src
 RUN pnpm -r build
 
-FROM directus/directus:10.12.1
+FROM directus/directus:11.1.1
 
 # Update via `npm run docker:ls:update`
 # START: EXTENSIONS-RUN-BLOCK

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
 		"init": "./scripts/init.sh",
 		"init:dev": "./scripts/init.sh --dev",
 		"docker:ls:update": "node ./scripts/docker-ls.js",
-		"migrate": "rm -rf ./extensions/migrations/* && mkdir -p ./extensions/migrations/ && cp -rp ./src/extensions/migrations/* ./extensions/migrations/ && cp -p ./src/extensions/migration-utils.js ./extensions/ && dotenv -- npx directus@10.12.1 database migrate:latest",
+		"migrate": "rm -rf ./extensions/migrations/* && mkdir -p ./extensions/migrations/ && cp -rp ./src/extensions/migrations/* ./extensions/migrations/ && cp -p ./src/extensions/migration-utils.js ./extensions/ && dotenv -- npx directus@11.1.1 database migrate:latest",
 		"seed": "NODE_ENV=development dotenv -- knex seed:run",
-		"schema:apply": "npx directus@10.12.1 schema apply --yes snapshots/collections-schema.yml",
-		"schema:snapshot": "npx directus@10.12.1 schema snapshot --yes snapshots/collections-schema.yml",
+		"schema:apply": "npx directus@11.1.1 schema apply --yes snapshots/collections-schema.yml",
+		"schema:snapshot": "npx directus@11.1.1 schema snapshot --yes snapshots/collections-schema.yml",
 		"prepare": "husky install || echo 'Failed to install husky'; rm -f .eslintcache",
 		"build:in-sequence": "grep -E 'AS builder-[0-9]+' Dockerfile | awk -F 'AS ' '{print $2}' | xargs -r -P 1 -I STAGE docker build --target STAGE ."
 	},

--- a/snapshots/collections-schema.yml
+++ b/snapshots/collections-schema.yml
@@ -1,5 +1,5 @@
 version: 1
-directus: 10.12.1
+directus: 11.1.1
 vendor: mysql
 collections:
   - collection: gp_adopted_probes

--- a/src/extensions/migration-utils.js
+++ b/src/extensions/migration-utils.js
@@ -1,11 +1,11 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
 // MANAGE USER PERMISSIONS
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -17,8 +17,8 @@ async function getUserRoleId () {
 }
 
 export async function getUserPermissions (collectionName) {
-	const userRoleId = await getUserRoleId();
-	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=${collectionName}&filter[role][_eq]=${userRoleId}&access_token=${ADMIN_ACCESS_TOKEN}`;
+	const policyId = await getUserPolicyId();
+	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=${collectionName}&filter[policy][_eq]=${policyId}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -36,23 +36,23 @@ export async function getUserPermissions (collectionName) {
 	return { readPermissions, createPermissions, updatePermissions, deletePermissions };
 }
 
-export async function updatePermissions (readPermissions, fieldsToAdd, fieldsToRemove) {
-	if (!readPermissions) {
+export async function updatePermissions (permissionsObj, fieldsToAdd, fieldsToRemove) {
+	if (!permissionsObj) {
 		throw new Error(`Permissions object is empty.`);
 	}
 
-	if (!readPermissions.id) {
-		console.error(readPermissions);
+	if (!permissionsObj.id) {
+		console.error(permissionsObj);
 		throw new Error(`Permissions ID is missing. This may happen when there are multiple rows for the same permission type.`);
 	}
 
-	const URL = `${DIRECTUS_URL}/permissions/${readPermissions.id}?access_token=${ADMIN_ACCESS_TOKEN}`;
-	const filteredFields = readPermissions.fields.filter(field => !fieldsToRemove.includes(field));
+	const URL = `${DIRECTUS_URL}/permissions/${permissionsObj.id}?access_token=${ADMIN_ACCESS_TOKEN}`;
+	const filteredFields = permissionsObj.fields.filter(field => !fieldsToRemove.includes(field));
 
 	const response = await fetch(URL, {
 		method: 'PATCH',
 		body: JSON.stringify({
-			...readPermissions,
+			...permissionsObj,
 			fields: [
 				...filteredFields,
 				...fieldsToAdd,

--- a/src/extensions/migrations/20230913GP-add-credits-read-permissions.js
+++ b/src/extensions/migrations/20230913GP-add-credits-read-permissions.js
@@ -1,9 +1,9 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -14,7 +14,7 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function createPermissions (roleId) {
+async function createPermissions (policyId) {
 	const URL = `${DIRECTUS_URL}/permissions?access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL, {
 		method: 'POST',
@@ -22,7 +22,7 @@ async function createPermissions (roleId) {
 			{
 				collection: 'credits',
 				action: 'read',
-				role: roleId,
+				policy: policyId,
 				permissions: {
 					_and: [
 						{
@@ -55,8 +55,8 @@ async function createPermissions (roleId) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	await createPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	await createPermissions(policyId);
 	console.log(`Read credits permissions added`);
 }
 

--- a/src/extensions/migrations/20230929GP-add-adopted-probes-permissions.js
+++ b/src/extensions/migrations/20230929GP-add-adopted-probes-permissions.js
@@ -1,9 +1,9 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -14,7 +14,7 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function createPermissions (roleId) {
+async function createPermissions (policyId) {
 	const URL = `${DIRECTUS_URL}/permissions?access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL, {
 		method: 'POST',
@@ -22,7 +22,7 @@ async function createPermissions (roleId) {
 			{
 				collection: 'adopted_probes',
 				action: 'read',
-				role: roleId,
+				policy: policyId,
 				permissions: {
 					_and: [
 						{
@@ -62,8 +62,8 @@ async function createPermissions (roleId) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	await createPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	await createPermissions(policyId);
 	console.log(`Read credits permissions added`);
 }
 

--- a/src/extensions/migrations/20231109GP-add-user-permissions.js
+++ b/src/extensions/migrations/20231109GP-add-user-permissions.js
@@ -1,9 +1,9 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -14,8 +14,8 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function getUserPermissions (roleId) {
-	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=directus_users&filter[role][_eq]=${roleId}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPermissions (policyId) {
+	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=directus_users&filter[policy][_eq]=${policyId}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -92,8 +92,8 @@ async function patchUpdatePermissions (updatePermissions) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	const { readPermissions, updatePermissions } = await getUserPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	const { readPermissions, updatePermissions } = await getUserPermissions(policyId);
 	await patchReadPermissions(readPermissions);
 	await patchUpdatePermissions(updatePermissions);
 	console.log('User permissions patched');

--- a/src/extensions/migrations/20231110GP-add-adopted-probes-update-permissions.js
+++ b/src/extensions/migrations/20231110GP-add-adopted-probes-update-permissions.js
@@ -1,9 +1,9 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -14,8 +14,8 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function getUserPermissions (roleId) {
-	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=adopted_probes&filter[role][_eq]=${roleId}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPermissions (policyId) {
+	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=adopted_probes&filter[policy][_eq]=${policyId}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -56,7 +56,7 @@ async function patchReadPermissions (readPermissions) {
 	return response.data;
 }
 
-async function createUpdatePermissions (roleId) {
+async function createUpdatePermissions (policyId) {
 	const URL = `${DIRECTUS_URL}/permissions?access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL, {
 		method: 'POST',
@@ -64,7 +64,7 @@ async function createUpdatePermissions (roleId) {
 			{
 				collection: 'adopted_probes',
 				action: 'update',
-				role: roleId,
+				policy: policyId,
 				permissions: {
 					_and: [
 						{
@@ -83,7 +83,7 @@ async function createUpdatePermissions (roleId) {
 			{
 				collection: 'adopted_probes',
 				action: 'delete',
-				role: roleId,
+				policy: policyId,
 				permissions: {
 					_and: [
 						{
@@ -109,10 +109,10 @@ async function createUpdatePermissions (roleId) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	const { readPermissions } = await getUserPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	const { readPermissions } = await getUserPermissions(policyId);
 	await patchReadPermissions(readPermissions);
-	await createUpdatePermissions(roleId);
+	await createUpdatePermissions(policyId);
 	console.log('Adopted probes update permissions added');
 }
 

--- a/src/extensions/migrations/20231217GP-update-credits-read-permissions.js
+++ b/src/extensions/migrations/20231217GP-update-credits-read-permissions.js
@@ -1,9 +1,9 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -14,8 +14,8 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function getUserPermissions (roleId) {
-	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=credits&filter[role][_eq]=${roleId}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPermissions (policyId) {
+	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=credits&filter[policy][_eq]=${policyId}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -54,8 +54,8 @@ async function patchReadPermissions (readPermissions) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	const { readPermissions } = await getUserPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	const { readPermissions } = await getUserPermissions(policyId);
 	await patchReadPermissions(readPermissions);
 	console.log('Credits read permissions updated.');
 }

--- a/src/extensions/migrations/20231218GP-update-adopted-probes-read-permissions.js
+++ b/src/extensions/migrations/20231218GP-update-adopted-probes-read-permissions.js
@@ -1,9 +1,9 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -14,8 +14,8 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function getUserPermissions (roleId) {
-	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=adopted_probes&filter[role][_eq]=${roleId}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPermissions (policyId) {
+	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=adopted_probes&filter[policy][_eq]=${policyId}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -54,8 +54,8 @@ async function patchReadPermissions (readPermissions) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	const { readPermissions } = await getUserPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	const { readPermissions } = await getUserPermissions(policyId);
 	await patchReadPermissions(readPermissions);
 	console.log('Credits read permissions updated.');
 }

--- a/src/extensions/migrations/20240104GP-add-user-permissions-to-read-gh-data.js
+++ b/src/extensions/migrations/20240104GP-add-user-permissions-to-read-gh-data.js
@@ -1,9 +1,9 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -14,8 +14,8 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function getUserPermissions (roleId) {
-	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=directus_users&filter[role][_eq]=${roleId}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPermissions (policyId) {
+	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=directus_users&filter[policy][_eq]=${policyId}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -57,8 +57,8 @@ async function patchReadPermissions (readPermissions) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	const { readPermissions } = await getUserPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	const { readPermissions } = await getUserPermissions(policyId);
 	await patchReadPermissions(readPermissions);
 	console.log('User permissions patched to read new gh fields');
 }

--- a/src/extensions/migrations/20240201GP-add-credits-read-permissions.js
+++ b/src/extensions/migrations/20240201GP-add-credits-read-permissions.js
@@ -1,9 +1,9 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -14,7 +14,7 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function createPermissions (roleId) {
+async function createPermissions (policyId) {
 	const URL = `${DIRECTUS_URL}/permissions?access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL, {
 		method: 'POST',
@@ -22,7 +22,7 @@ async function createPermissions (roleId) {
 			{
 				collection: 'gp_credits_additions',
 				action: 'read',
-				role: roleId,
+				policy: policyId,
 				permissions: {
 					_and: [
 						{
@@ -42,7 +42,7 @@ async function createPermissions (roleId) {
 			{
 				collection: 'gp_credits_deductions',
 				action: 'read',
-				role: roleId,
+				policy: policyId,
 				permissions: {
 					_and: [
 						{
@@ -73,8 +73,8 @@ async function createPermissions (roleId) {
 	return response.data;
 }
 
-async function getUserPermissions (roleId) {
-	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=gp_credits&filter[role][_eq]=${roleId}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPermissions (policyId) {
+	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=gp_credits&filter[policy][_eq]=${policyId}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -122,9 +122,9 @@ async function patchReadPermissions (readPermissions) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	await createPermissions(roleId);
-	const { readPermissions } = await getUserPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	await createPermissions(policyId);
+	const { readPermissions } = await getUserPermissions(policyId);
 	await patchReadPermissions(readPermissions);
 	console.log(`Read credits permissions added`);
 }

--- a/src/extensions/migrations/20240215GP-add-user-permissions-to-read-type.js
+++ b/src/extensions/migrations/20240215GP-add-user-permissions-to-read-type.js
@@ -1,9 +1,9 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -14,8 +14,8 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function getUserPermissions (roleId) {
-	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=directus_users&filter[role][_eq]=${roleId}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPermissions (policyId) {
+	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=directus_users&filter[policy][_eq]=${policyId}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -55,8 +55,8 @@ async function patchReadPermissions (readPermissions) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	const { readPermissions } = await getUserPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	const { readPermissions } = await getUserPermissions(policyId);
 	await patchReadPermissions(readPermissions);
 	console.log('User permissions patched to read user type');
 }

--- a/src/extensions/migrations/20240221GP-add-permissions-to-read-adopted-hardware.js
+++ b/src/extensions/migrations/20240221GP-add-permissions-to-read-adopted-hardware.js
@@ -1,13 +1,13 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
 const COLLECTION_NAME = 'gp_adopted_probes';
 const FIELDS_TO_REMOVE = [];
 const FIELDS_TO_ADD = [ 'hardwareDevice' ];
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -18,8 +18,8 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function getUserPermissions (roleId) {
-	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=${COLLECTION_NAME}&filter[role][_eq]=${roleId}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPermissions (policyId) {
+	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=${COLLECTION_NAME}&filter[policy][_eq]=${policyId}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -60,8 +60,8 @@ async function patchReadPermissions (readPermissions) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	const { readPermissions } = await getUserPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	const { readPermissions } = await getUserPermissions(policyId);
 	await patchReadPermissions(readPermissions);
 	console.log('User permissions patched read adopted probes "hardwareDevice" field');
 }

--- a/src/extensions/migrations/20240222GP-add-permissions-to-read-credits-addition-probe.js
+++ b/src/extensions/migrations/20240222GP-add-permissions-to-read-credits-addition-probe.js
@@ -1,13 +1,13 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
 const COLLECTION_NAME = 'gp_credits_additions';
 const FIELDS_TO_REMOVE = [];
 const FIELDS_TO_ADD = [ 'adopted_probe' ];
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -18,8 +18,8 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function getUserPermissions (roleId) {
-	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=${COLLECTION_NAME}&filter[role][_eq]=${roleId}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPermissions (policyId) {
+	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=${COLLECTION_NAME}&filter[policy][_eq]=${policyId}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -60,8 +60,8 @@ async function patchReadPermissions (readPermissions) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	const { readPermissions } = await getUserPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	const { readPermissions } = await getUserPermissions(policyId);
 	await patchReadPermissions(readPermissions);
 	console.log('User permissions patched to read credits additions "adopted_probe" field');
 }

--- a/src/extensions/migrations/20240223GP-add-user-patch-permissions-firstname-lastname.js
+++ b/src/extensions/migrations/20240223GP-add-user-patch-permissions-firstname-lastname.js
@@ -1,13 +1,13 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
 const COLLECTION_NAME = 'directus_users';
 const FIELDS_TO_REMOVE = [];
 const FIELDS_TO_ADD = [ 'first_name', 'last_name', 'email' ];
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -18,8 +18,8 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function getUserPermissions (roleId) {
-	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=${COLLECTION_NAME}&filter[role][_eq]=${roleId}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPermissions (policyId) {
+	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=${COLLECTION_NAME}&filter[policy][_eq]=${policyId}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -60,13 +60,13 @@ async function patchUpdatePermissions (updatePermissions) {
 	return response.data;
 }
 
-async function postDeletePermission (roleId) {
+async function postDeletePermission (policyId) {
 	const URL = `${DIRECTUS_URL}/permissions?access_token=${ADMIN_ACCESS_TOKEN}`;
 
 	const response = await fetch(URL, {
 		method: 'POST',
 		body: JSON.stringify({
-			role: roleId,
+			policy: policyId,
 			collection: 'directus_users',
 			action: 'delete',
 			permissions: {
@@ -93,10 +93,10 @@ async function postDeletePermission (roleId) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	const { updatePermissions } = await getUserPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	const { updatePermissions } = await getUserPermissions(policyId);
 	await patchUpdatePermissions(updatePermissions);
-	await postDeletePermission(roleId);
+	await postDeletePermission(policyId);
 	console.log('User permissions patched to edit "first_name", "last_name", "email" and delete account.');
 }
 

--- a/src/extensions/migrations/20240423GP-add-permissions-to-read-adopted-node-version.js
+++ b/src/extensions/migrations/20240423GP-add-permissions-to-read-adopted-node-version.js
@@ -1,13 +1,13 @@
 const DIRECTUS_URL = process.env.DIRECTUS_URL;
 const ADMIN_ACCESS_TOKEN = process.env.ADMIN_ACCESS_TOKEN;
-const USER_ROLE_NAME = 'User';
+const USER_POLICY_NAME = 'User';
 
 const COLLECTION_NAME = 'gp_adopted_probes';
 const FIELDS_TO_REMOVE = [];
 const FIELDS_TO_ADD = [ 'nodeVersion' ];
 
-async function getUserRoleId () {
-	const URL = `${DIRECTUS_URL}/roles?filter[name][_eq]=${USER_ROLE_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPolicyId () {
+	const URL = `${DIRECTUS_URL}/policies?filter[name][_eq]=${USER_POLICY_NAME}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -18,8 +18,8 @@ async function getUserRoleId () {
 	return response.data[0].id;
 }
 
-async function getUserPermissions (roleId) {
-	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=${COLLECTION_NAME}&filter[role][_eq]=${roleId}&access_token=${ADMIN_ACCESS_TOKEN}`;
+async function getUserPermissions (policyId) {
+	const URL = `${DIRECTUS_URL}/permissions?filter[collection][_eq]=${COLLECTION_NAME}&filter[policy][_eq]=${policyId}&access_token=${ADMIN_ACCESS_TOKEN}`;
 	const response = await fetch(URL).then((response) => {
 		if (!response.ok) {
 			throw new Error(`Fetch request failed. Status: ${response.status}`);
@@ -60,8 +60,8 @@ async function patchReadPermissions (readPermissions) {
 }
 
 export async function up () {
-	const roleId = await getUserRoleId();
-	const { readPermissions } = await getUserPermissions(roleId);
+	const policyId = await getUserPolicyId();
+	const { readPermissions } = await getUserPermissions(policyId);
 	await patchReadPermissions(readPermissions);
 	console.log('User permissions patched read adopted probes "nodeVersion" field');
 }


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping-dash-directus/issues/37.

This fixes clean setup of v11. 

Not sure why upgrade from v10 to v11 failed. Order of steps is:
- rebuild and run the v11 container;
- `pnpm run schema:apply`;
- `pnpm run migrate`.