### PR TITLE
fix: sign up users without emails on github

### DIFF
--- a/src/extensions/hooks/sign-up/src/index.ts
+++ b/src/extensions/hooks/sign-up/src/index.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 type User = {
     provider: string;
     external_identifier: string;
+		email?: string | undefined;
     first_name?: string;
     last_name?: string;
     last_page?: string;
@@ -24,6 +25,17 @@ type CreditsAdditions = {
 };
 
 export default defineHook(({ filter, action }, context) => {
+	// For users without emails, Directus sets `email` to `undefined`, instead of removing that field.
+	// That throws on validation here: https://github.com/directus/directus/blob/2991169f82ad5d0c461e82e7fdcb268ef737896c/api/src/services/users.ts#L164-L165
+	// Issue should be fixed by Directus, but as a temp solution we are removing that field manually.
+	filter('auth.create', async (payload) => {
+		const user = payload as User;
+
+		if (!user.email) {
+			delete user.email;
+		}
+	});
+
 	filter('users.create', async (payload) => {
 		const user = payload as User;
 

--- a/src/extensions/hooks/sign-up/test/index.test.ts
+++ b/src/extensions/hooks/sign-up/test/index.test.ts
@@ -85,6 +85,31 @@ describe('Sign-up hook', () => {
 		nock.cleanAll();
 	});
 
+	it(`filter should remove 'email' field if it is falsy`, async () => {
+		hook(events, context);
+
+		const payload = {
+			auth_data: undefined,
+			email: undefined,
+			external_identifier: '1834071',
+			first_name: 'Dmitriy Akulov',
+			last_name: 'jimaek',
+			provider: 'github',
+			role: 'role-uuid',
+		};
+
+		await callbacks.filter['auth.create']?.(payload);
+
+		expect(payload).to.deep.equal({
+			auth_data: undefined,
+			external_identifier: '1834071',
+			first_name: 'Dmitriy Akulov',
+			last_name: 'jimaek',
+			provider: 'github',
+			role: 'role-uuid',
+		});
+	});
+
 	it('filter should fulfill first_name, last_name, github_username', async () => {
 		nock('https://api.github.com')
 			.get(`/user/1834071/orgs`)


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping-dash/issues/48

I'll also report that issue to Directus and attach here.