### PR TITLE
feat: add migration to mark old tags format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
           node-version: 20.x
       - name: Build and Test
         run: |
+          : # Temp corepack fix: https://github.com/nodejs/corepack/issues/612
+          corepack install -g pnpm@9.15.2
+
           corepack enable
           pnpm install
           pnpm -r build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,9 @@ jobs:
           node-version: 20.x
       - name: Install dependencies
         run: |
+          : # Temp corepack fix: https://github.com/nodejs/corepack/issues/612
+          corepack install -g pnpm@9.15.2
+
           corepack enable
           pnpm install
       - name: Install Playwright browsers

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM node:20-alpine AS builder
+
+# Temp corepack fix: https://github.com/nodejs/corepack/issues/612
+RUN corepack install -g pnpm@9.15.2
+
 RUN corepack enable
 WORKDIR /builder
 COPY package.json pnpm-*.yaml ./

--- a/src/extensions/migrations/20250131GP-mark-user-tags-as-old-format.js
+++ b/src/extensions/migrations/20250131GP-mark-user-tags-as-old-format.js
@@ -1,0 +1,17 @@
+export async function up (knex) {
+	const probesWithTags = await knex('gp_adopted_probes').select().whereNot({ tags: '[]' });
+
+	probesWithTags.forEach((probe) => {
+		probe.tags = JSON.stringify(JSON.parse(probe.tags).map(tag => ({ ...tag, format: 'v1' })));
+	});
+
+	for (const probe of probesWithTags) {
+		await knex('gp_adopted_probes').where({ id: probe.id }).update({ tags: probe.tags });
+	}
+
+	console.log('Marked user tags as old format');
+}
+
+export async function down () {
+	console.log('There is no down operation for that migration.');
+}


### PR DESCRIPTION
Part of https://github.com/jsdelivr/globalping/issues/613

Updating of tags field triggers saving without `format` field, so tags are updated to the new format.