### PR TITLE
feat: make probe names required

### DIFF
--- a/src/extensions/endpoints/adoption-code/src/repositories/directus.ts
+++ b/src/extensions/endpoints/adoption-code/src/repositories/directus.ts
@@ -1,5 +1,6 @@
 import type { EndpointExtensionContext } from '@directus/extensions';
 import _ from 'lodash';
+import { getDefaultProbeName } from '../../../../lib/src/default-probe-name.js';
 import type { AdoptedProbe, ProbeToAdopt } from '../index.js';
 
 export const createAdoptedProbe = async (userId: string, probe: ProbeToAdopt, context: EndpointExtensionContext) => {
@@ -89,35 +90,6 @@ export const createAdoptedProbe = async (userId: string, probe: ProbeToAdopt, co
 	await sendNotificationProbeAdopted({ ...adoption, id }, context);
 	const adoptedProbe = await itemsService.readOne(id);
 	return adoptedProbe;
-};
-
-const findAdoptedProbes = async (filter: Record<string, unknown>, { services, getSchema, database }: EndpointExtensionContext) => {
-	const itemsService = new services.ItemsService('gp_probes', {
-		schema: await getSchema({ database }),
-		knex: database,
-	});
-
-	const probes = await itemsService.readByQuery({
-		filter,
-	}) as ProbeToAdopt[];
-
-	return probes;
-};
-
-const getDefaultProbeName = async (userId: string, probe: ProbeToAdopt, context: EndpointExtensionContext) => {
-	let name = null;
-	const namePrefix = probe.country && probe.city ? `probe-${probe.country.toLowerCase().replaceAll(' ', '-')}-${probe.city.toLowerCase().replaceAll(' ', '-')}` : null;
-
-	if (namePrefix) {
-		const currentProbes = await findAdoptedProbes({
-			userId,
-			country: probe.country,
-			city: probe.city,
-		}, context);
-		name = `${namePrefix}-${(currentProbes.length + 1).toString().padStart(2, '0')}`;
-	}
-
-	return name;
 };
 
 export const findAdoptedProbeByIp = async (ip: string, { database }: EndpointExtensionContext) => {

--- a/src/extensions/endpoints/adoption-code/test/index.test.ts
+++ b/src/extensions/endpoints/adoption-code/test/index.test.ts
@@ -936,7 +936,7 @@ describe('adoption code endpoints', () => {
 				},
 			}, res);
 
-			readByQuery.resolves([{}]);
+			readByQuery.resolves([{ id: 'otherProbeId' }]);
 
 			await request('/verify-code', {
 				accountability: {
@@ -981,7 +981,7 @@ describe('adoption code endpoints', () => {
 				},
 			}, res);
 
-			readByQuery.resolves([{}]);
+			readByQuery.resolves([{ id: 'otherProbeId' }]);
 
 			await request('/verify-code', {
 				accountability: {

--- a/src/extensions/hooks/adopted-probe/src/index.ts
+++ b/src/extensions/hooks/adopted-probe/src/index.ts
@@ -1,6 +1,6 @@
 import { createError } from '@directus/errors';
 import { defineHook } from '@directus/extensions-sdk';
-import { resetCustomLocation, resetUserDefinedData, updateCustomLocationData } from './update-metadata.js';
+import { resetCustomLocation, resetUserDefinedData, updateCustomLocationData, updateProbeName } from './update-metadata.js';
 import { validateCustomLocation, validateTags } from './validate-fields.js';
 
 export type Probe = {
@@ -31,6 +31,7 @@ export default defineHook(({ filter, action }, context) => {
 		await Promise.all([
 			(fields.tags && fields.tags.length > 0) && validateTags(fields, keys, accountability, context),
 			(fields.city || fields.country) && validateCustomLocation(fields, keys, accountability, context),
+			(Object.hasOwn(fields, 'name') && !fields.name) && updateProbeName(fields, keys, accountability, context),
 		]);
 	});
 

--- a/src/extensions/hooks/adopted-probe/tsconfig.json
+++ b/src/extensions/hooks/adopted-probe/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"compilerOptions": {
-		"target": "ES2021",
+		"target": "ES2022",
 		"lib": [
-			"ES2021"
+			"ES2023"
 		],
 		"moduleResolution": "node",
 		"module": "ESNext",

--- a/src/extensions/lib/src/default-probe-name.ts
+++ b/src/extensions/lib/src/default-probe-name.ts
@@ -20,7 +20,7 @@ const findAdoptedProbes = async (filter: Record<string, unknown>, { services, ge
 };
 
 export const getDefaultProbeName = async (userId: string, probe: Probe, context: ApiExtensionContext) => {
-	let name = null;
+	let name: string | null = null;
 	const namePrefix = probe.country && probe.city ? `probe-${probe.country.toLowerCase().replaceAll(' ', '-')}-${probe.city.toLowerCase().replaceAll(' ', '-')}` : null;
 
 	if (namePrefix) {

--- a/src/extensions/lib/src/default-probe-name.ts
+++ b/src/extensions/lib/src/default-probe-name.ts
@@ -1,0 +1,37 @@
+import type { ApiExtensionContext } from '@directus/extensions';
+
+type Probe = {
+	id?: string;
+	country?: string | null;
+	city?: string | null;
+};
+
+const findAdoptedProbes = async (filter: Record<string, unknown>, { services, getSchema, database }: ApiExtensionContext) => {
+	const itemsService = new services.ItemsService('gp_probes', {
+		schema: await getSchema({ database }),
+		knex: database,
+	});
+
+	const probes = await itemsService.readByQuery({
+		filter,
+	}) as Probe[];
+
+	return probes;
+};
+
+export const getDefaultProbeName = async (userId: string, probe: Probe, context: ApiExtensionContext) => {
+	let name = null;
+	const namePrefix = probe.country && probe.city ? `probe-${probe.country.toLowerCase().replaceAll(' ', '-')}-${probe.city.toLowerCase().replaceAll(' ', '-')}` : null;
+
+	if (namePrefix) {
+		const currentProbes = await findAdoptedProbes({
+			userId,
+			country: probe.country,
+			city: probe.city,
+		}, context);
+		const otherProbes = currentProbes.filter(({ id }) => id !== probe.id);
+		name = `${namePrefix}-${(otherProbes.length + 1).toString().padStart(2, '0')}`;
+	}
+
+	return name;
+};

--- a/src/extensions/migrations/20250621GP-fulfill-probe-name.js
+++ b/src/extensions/migrations/20250621GP-fulfill-probe-name.js
@@ -1,0 +1,28 @@
+import _ from 'lodash';
+
+export async function up (knex) {
+	const TABLE_NAME = 'gp_probes';
+	const probes = await knex(TABLE_NAME).select().whereNotNull('userId');
+	const probesWithName = probes.filter(p => p.name);
+	const probesWithoutName = probes.filter(p => !p.name);
+
+	const groupedProbes = _.groupBy(probesWithName, p => `${p.userId}_${p.country}_${p.city}`);
+
+	for (const probe of probesWithoutName) {
+		const key = `${probe.userId}_${probe.country}_${probe.city}`;
+		const otherProbes = groupedProbes[key] || [];
+		const name = `probe-${probe.country.toLowerCase().replaceAll(' ', '-')}-${probe.city.toLowerCase().replaceAll(' ', '-')}-${(otherProbes.length + 1).toString().padStart(2, '0')}`;
+		await knex(TABLE_NAME).where({ id: probe.id }).update({ name });
+		const newKey = `${probe.userId}_${probe.country}_${probe.city}`;
+
+		if (!groupedProbes[newKey]) { groupedProbes[newKey] = []; }
+
+		groupedProbes[newKey].push({ ...probe, name });
+	}
+
+	console.log('Default probe names fulfilled');
+}
+
+export async function down () {
+	console.log('There is no down operation for that migration.');
+}


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping-dash-directus/issues/94

Unassigned probes are still stored without names, which makes sense from my point of view. If that logic should be added too, please let me know.