### PR TITLE
fix: email sending gap locks

### DIFF
--- a/snapshots/collections-schema.yml
+++ b/snapshots/collections-schema.yml
@@ -402,7 +402,7 @@ fields:
       numeric_scale: null
       is_nullable: false
       is_unique: false
-      is_indexed: false
+      is_indexed: true
       is_primary_key: false
       is_generated: false
       generation_expression: null

--- a/src/extensions/hooks/email-sender/src/email-sender.ts
+++ b/src/extensions/hooks/email-sender/src/email-sender.ts
@@ -61,52 +61,60 @@ export class EmailService {
 	}
 
 	private async handleEmails () {
-		const { toSend, rowsCount } = await this.context.database.transaction(async (trx) => {
-			const rows = await trx('directus_notifications as notifications')
-				.leftJoin('directus_users as users', 'users.id', 'notifications.recipient')
-				.select<NotificationRow[]>([
-					'notifications.id',
-					'notifications.recipient',
-					'notifications.type',
-					'notifications.subject',
-					'notifications.message',
-					'users.email',
+		const rows = await this.context.database.transaction(async (trx) => {
+			const claimed = await trx('directus_notifications')
+				.select<Omit<NotificationRow, 'email'>[]>([
+					'id',
+					'recipient',
+					'type',
+					'subject',
+					'message',
 				])
-				.where('notifications.email_status', 'pending')
+				.where('email_status', 'pending')
 				.andWhere((query) => {
-					query.whereNull('notifications.email_last_attempt')
-						.orWhere('notifications.email_last_attempt', '<=', new Date(Date.now() - 60_000));
+					query.whereNull('email_last_attempt')
+						.orWhere('email_last_attempt', '<=', new Date(Date.now() - 60_000));
 				})
-				.orderBy('notifications.id', 'asc')
+				.orderBy('id', 'asc')
 				.limit(this.BATCH_SIZE)
 				.forUpdate()
 				.skipLocked();
 
-			const noEmailIds: number[] = [];
-			const toSend: NotificationRow[] = [];
-
-			for (const row of rows) {
-				if (row.email) {
-					toSend.push({ ...row, email: row.email });
-				} else {
-					noEmailIds.push(row.id);
-				}
-			}
-
-			if (noEmailIds.length > 0) {
+			if (claimed.length > 0) {
 				await trx('directus_notifications')
-					.whereIn('id', noEmailIds)
-					.update({ email_status: 'no-email' });
-			}
-
-			if (toSend.length > 0) {
-				await trx('directus_notifications')
-					.whereIn('id', toSend.map(({ id }) => id))
+					.whereIn('id', claimed.map(({ id }) => id))
 					.update({ email_last_attempt: new Date() });
 			}
 
-			return { toSend, rowsCount: rows.length };
+			return claimed;
 		});
+
+		if (rows.length === 0) {
+			return 0;
+		}
+
+		const recipientIds = [ ...new Set(rows.map(({ recipient }) => recipient)) ];
+		const users = await this.context.database('directus_users')
+			.select<{ id: string; email: string | null }[]>([ 'id', 'email' ])
+			.whereIn('id', recipientIds);
+		const emailByRecipient = new Map(users.map(({ id, email }) => [ id, email ]));
+
+		const noEmailIds: number[] = [];
+		const toSend: NotificationRow[] = [];
+
+		for (const row of rows) {
+			const email = emailByRecipient.get(row.recipient);
+
+			if (email) {
+				toSend.push({ ...row, email });
+			} else {
+				noEmailIds.push(row.id);
+			}
+		}
+
+		if (noEmailIds.length > 0) {
+			await this.context.database('directus_notifications').whereIn('id', noEmailIds).update({ email_status: 'no-email' });
+		}
 
 		if (toSend.length > 0) {
 			const { sentIds, failedIds } = await this.sendEmails(toSend);
@@ -114,7 +122,7 @@ export class EmailService {
 			failedIds.length > 0 && await this.context.database('directus_notifications').whereIn('id', failedIds).update({ email_status: 'failed' });
 		}
 
-		return rowsCount;
+		return rows.length;
 	}
 
 	private async sendEmails (notifications: NotificationRow[]) {

--- a/src/extensions/hooks/email-sender/test/index.test.ts
+++ b/src/extensions/hooks/email-sender/test/index.test.ts
@@ -18,49 +18,52 @@ type MinimalContext = {
 const createContext = (rows: any[] = []): MinimalContext => {
 	const error = sinon.stub();
 	const updates: Array<{ ids: number[]; patch: Record<string, unknown> }> = [];
-	const trxUpdate = sinon.stub().resolves(1);
-	const trxBuilder = {
-		leftJoin: () => trxBuilder,
-		select: () => trxBuilder,
-		where: () => trxBuilder,
-		andWhere: (fn: (q: any) => void) => {
-			const query = {
-				whereNull: () => query,
-				orWhere: () => query,
-			};
-			fn(query);
-			return trxBuilder;
-		},
-		orderBy: () => trxBuilder,
-		limit: () => trxBuilder,
-		forUpdate: () => trxBuilder,
-		skipLocked: async () => rows,
-		whereIn: () => ({
-			update: trxUpdate,
-		}),
-	};
-	const trx = (table: string) => {
-		if (table === 'directus_notifications as notifications') {
-			return trxBuilder;
-		}
 
-		return {
-			whereIn: (_key: string, ids: number[]) => ({
-				update: async (patch: Record<string, unknown>) => {
-					updates.push({ ids, patch });
-					return 1;
-				},
-			}),
-		};
-	};
-	const database = (() => ({
+	const record = {
 		whereIn: (_key: string, ids: number[]) => ({
 			update: async (patch: Record<string, unknown>) => {
 				updates.push({ ids, patch });
 				return 1;
 			},
 		}),
-	})) as any;
+	};
+
+	const notificationsBuilder: any = {
+		select: () => notificationsBuilder,
+		where: () => notificationsBuilder,
+		andWhere: (fn: (q: any) => void) => {
+			const query = {
+				whereNull: () => query,
+				orWhere: () => query,
+			};
+			fn(query);
+			return notificationsBuilder;
+		},
+		orderBy: () => notificationsBuilder,
+		limit: () => notificationsBuilder,
+		forUpdate: () => notificationsBuilder,
+		skipLocked: async () => rows,
+		whereIn: record.whereIn,
+	};
+
+	const usersBuilder: any = {
+		select: () => usersBuilder,
+		whereIn: async (_key: string, ids: string[]) => {
+			const emailByRecipient = new Map<string, string | null>();
+
+			for (const row of rows) {
+				if (!emailByRecipient.has(row.recipient)) {
+					emailByRecipient.set(row.recipient, row.email ?? null);
+				}
+			}
+
+			return ids.map(id => ({ id, email: emailByRecipient.get(id) ?? null }));
+		},
+	};
+
+	const trx = (table: string) => (table === 'directus_notifications' ? notificationsBuilder : record);
+
+	const database = ((table: string) => (table === 'directus_users' ? usersBuilder : record)) as any;
 	database.transaction = async (cb: (trx: any) => Promise<any>) => cb(trx);
 	database.__updates = updates;
 
@@ -196,10 +199,10 @@ describe('EmailService', () => {
 		const updates = context.database.__updates;
 
 		expect(count).to.equal(2);
-		expect(updates[0]?.ids).to.deep.equal([ 1 ]);
-		expect(updates[0]?.patch).to.include({ email_status: 'no-email' });
-		expect(updates[1]?.ids).to.deep.equal([ 2 ]);
-		expect(updates[1]?.patch).to.have.keys('email_last_attempt');
+		expect(updates[0]?.ids).to.deep.equal([ 1, 2 ]);
+		expect(updates[0]?.patch).to.have.keys('email_last_attempt');
+		expect(updates[1]?.ids).to.deep.equal([ 1 ]);
+		expect(updates[1]?.patch).to.include({ email_status: 'no-email' });
 		expect(updates[2]).to.deep.equal({ ids: [ 2 ], patch: { email_status: 'sent' } });
 	});
 
@@ -221,7 +224,9 @@ describe('EmailService', () => {
 		expect(count).to.equal(100);
 		expect(sendEmails.called).to.equal(false);
 		expect(context.database.__updates[0]?.ids).to.have.length(100);
-		expect(context.database.__updates[0]?.patch).to.include({ email_status: 'no-email' });
+		expect(context.database.__updates[0]?.patch).to.have.keys('email_last_attempt');
+		expect(context.database.__updates[1]?.ids).to.have.length(100);
+		expect(context.database.__updates[1]?.patch).to.include({ email_status: 'no-email' });
 	});
 
 	it('should reschedule immediately when handled full batch', async () => {

--- a/src/extensions/migrations/20260518GP-add-notifications-index.js
+++ b/src/extensions/migrations/20260518GP-add-notifications-index.js
@@ -1,8 +1,0 @@
-export async function up (knex) {
-	await knex.raw(`ALTER TABLE directus_notifications ADD INDEX email_status_index (email_status);`);
-	console.log('Index "email_status_index" added');
-}
-
-export async function down () {
-	console.log('There is no down operation for that migration.');
-}

--- a/src/extensions/migrations/20260518GP-add-notifications-index.js
+++ b/src/extensions/migrations/20260518GP-add-notifications-index.js
@@ -1,0 +1,8 @@
+export async function up (knex) {
+	await knex.raw(`ALTER TABLE directus_notifications ADD INDEX email_status_index (email_status);`);
+	console.log('Index "email_status_index" added');
+}
+
+export async function down () {
+	console.log('There is no down operation for that migration.');
+}

--- a/src/extensions/operations/check-outdated-firmware-cron-handler/src/actions/check-outdated-firmware.ts
+++ b/src/extensions/operations/check-outdated-firmware-cron-handler/src/actions/check-outdated-firmware.ts
@@ -11,7 +11,7 @@ export const checkOutdatedFirmware = async (context: OperationContext): Promise<
 		const probes = await getOutdatedProbesForUsers(userId, context);
 		const notNotified = probes.filter(p => !alreadyNotifiedIds.has(p.id));
 		return notNotified.length === 0 ? [] : checkFirmwareVersions(notNotified, userId, context);
-	}, { concurrency: 8 });
+	}, { concurrency: 4 });
 
 	return ids.flat();
 };

--- a/src/extensions/operations/remove-expired-adoptions-cron-handler/src/repositories/directus.ts
+++ b/src/extensions/operations/remove-expired-adoptions-cron-handler/src/repositories/directus.ts
@@ -76,7 +76,7 @@ export const notifyAdoptions = async (probes: AdoptedProbe[], context: Operation
 		}
 
 		ids.push(...userProbes.map(p => p.id));
-	});
+	}, { concurrency: 4 });
 
 	return ids;
 };
@@ -137,7 +137,7 @@ export const deleteAdoptions = async (probes: AdoptedProbe[], { services, getSch
 			item: probe.id,
 			collection: 'gp_probes',
 		});
-	});
+	}, { concurrency: 4 });
 
 	let deletedAdoptionsIds: string[] = [];
 

--- a/src/extensions/operations/sponsors-cron-handler/src/actions/handle-sponsor-activities.ts
+++ b/src/extensions/operations/sponsors-cron-handler/src/actions/handle-sponsor-activities.ts
@@ -27,7 +27,7 @@ export class SponsorActivitiesHandler {
 		const results = await Bluebird.map(activitiesBySponsorId, (activities) => {
 			// Process activities of the same sponsor sequentially to avoid race conditions.
 			return Bluebird.map(activities, a => this.createAddition(a, context), { concurrency: 1 });
-		}, { concurrency: 8 });
+		}, { concurrency: 4 });
 
 		return results.flat().filter((r): r is string => r !== null);
 	}


### PR DESCRIPTION
Prev `email-sender.ts` select did a full scan, now it is indexed, plus join with `directus_users` removed.